### PR TITLE
feat: add systemd hardening directives to service file

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -662,6 +662,11 @@ Restart=always
 RestartSec=10
 Environment=HOME=$SYSTEMD_HOME
 Environment=OPENCLAW_HOME=$SYSTEMD_OPENCLAW_HOME
+NoNewPrivileges=true
+ProtectSystem=strict
+PrivateTmp=true
+MemoryMax=2G
+ReadWritePaths=$SYSTEMD_OPENCLAW_HOME /tmp/openclaw /var/www
 
 [Install]
 WantedBy=multi-user.target"


### PR DESCRIPTION
Adds security hardening to the systemd service created by setup.sh:

- **NoNewPrivileges=true** — prevent privilege escalation
- **ProtectSystem=strict** — read-only filesystem except allowed paths
- **PrivateTmp=true** — isolated /tmp namespace
- **MemoryMax=2G** — prevent runaway memory usage
- **ReadWritePaths** — only openclaw home, logs dir, and WordPress files are writable

These directives apply to both secure mode (openclaw user) and root mode, adding defense-in-depth even when running as root.

Part of fleet-wide security hardening effort.